### PR TITLE
fix: handle None linked_account for credit transactions without IBAN

### DIFF
--- a/importer2firefly.py
+++ b/importer2firefly.py
@@ -213,12 +213,20 @@ class Import2Firefly:
                                 )
                             ),
                             "source_id": (
-                                linked_account["id"]
+                                (
+                                    None
+                                    if linked_account is None
+                                    else linked_account["id"]
+                                )
                                 if transaction_type == "credit"
                                 else import_account["id"]
                             ),
                             "source_name": (
-                                linked_account["attributes"]["name"]
+                                (
+                                    "(unknown revenue account)"
+                                    if linked_account is None
+                                    else linked_account["attributes"]["name"]
+                                )
                                 if transaction_type == "credit"
                                 else import_account["attributes"]["name"]
                             ),


### PR DESCRIPTION
When a deposit/credit transaction has no counterparty IBAN, linked_account is set to None. The code already handled this for destination_id/name (expense accounts) but not for source_id/name (revenue accounts), causing 'NoneType' object is not subscriptable error.

Added the same None check for source_id and source_name fields, using "(unknown revenue account)" as fallback when linked_account is None.

---

I honestly have no time to test this properly, but I simply injected this version of the file in my docker container running the application with the latest version, and it imports everything correctly, at least it seems to me.

To the maintainer: Please review carefully this change as I am no expert of python and didn't really go into details about how the application works, I simply checked the file and noticed the pattern in how data is processed.

This should resolve #127 

